### PR TITLE
Using socket_io_client instead of websockets_channel

### DIFF
--- a/lib/utils/game_communication.dart
+++ b/lib/utils/game_communication.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'websocket.dart';
+import 'package:literature/utils/websocket.dart';
 
 ///
-/// Again, application-level global variable
+/// Global variable, the whole class is 
+/// accessible through this variable.
 ///
 GameCommunication game = new GameCommunication();
 
@@ -21,25 +22,24 @@ class GameCommunication {
   ///
   String _playerID = "";
 
-  //
-  // The game should have a Room ID
-  //
-  String _roomID = "";
-
+  /// Reuse the same instance of 
+  /// the class using "factory" identifier.
   factory GameCommunication(){
     return _game;
   }
 
+  // Private Constructor for the class.
   GameCommunication._internal(){
+    print("Game communication constructor");
     ///
     /// Let's initialize the WebSockets communication
     ///
-    sockets.initCommunication();
+    socket.initCommunication();
 
     ///
     /// and ask to be notified as soon as a message comes in
     /// 
-    sockets.addListener(_onMessageReceived);
+    socket.addListener(_onMessageReceived);
   }
 
   ///
@@ -57,6 +57,7 @@ class GameCommunication {
     /// JSON object
     ///
     Map message = json.decode(serverMessage);
+    print(message);
 
     switch(message["action"]){
       ///
@@ -96,10 +97,7 @@ class GameCommunication {
     /// Send the action to the server
     /// To send the message, we need to serialize the JSON 
     ///
-    sockets.send(json.encode({
-      "action": action,
-      "data": data
-    }));
+    socket.send(action, data);
   }
 
   /// ==========================================================

--- a/lib/utils/websocket.dart
+++ b/lib/utils/websocket.dart
@@ -1,93 +1,67 @@
 import 'package:flutter/foundation.dart';
-import 'package:web_socket_channel/io.dart';
+import 'package:socket_io_client/socket_io_client.dart' as IO;
 
-/// Application-level global variable to access the WebSockets
-///
-WebSocketsNotifications sockets = new WebSocketsNotifications();
+/// Global variable, the whole class
+/// is accessible by this global variable
+WebSocket socket = new WebSocket();
 
-///
-/// Put your WebSockets server IP address and port number
-///
-const String _SERVER_ADDRESS = "ws://192.168.1.45:34263";
+class WebSocket {
+  static final WebSocket _socketController = new WebSocket._internal();
 
-class WebSocketsNotifications {
-  static final WebSocketsNotifications _sockets = new WebSocketsNotifications._internal();
-
-  factory WebSocketsNotifications() {
-    return _sockets;
+  /// Reuse the same instance of websockets,
+  /// Called when Line 6 is called.
+  factory WebSocket() {
+    return _socketController;
   }
 
-  WebSocketsNotifications._internal();
+  WebSocket._internal();
+  
 
-  ///
-  /// The WebSocket "open" channel
-  ///
-  IOWebSocketChannel _channel;
+  // WebSocket channel
+  IO.Socket _channel;
 
-  ///
-  /// Is the connection established?
-  ///
+  // Is connection on?
   bool _isOn = false;
 
-  ///
-  /// Listeners
-  /// List of methods to be called when a new message
-  /// comes in.
-  ///
+  // Listeners to various events
   ObserverList<Function> _listeners = new ObserverList<Function>();
 
-  /// ----------------------------------------------------------
-  /// Initialization the WebSockets connection with the server
-  /// ----------------------------------------------------------
-  initCommunication() async {
-    ///
-    /// Just in case, close any previous communication
-    ///
-    reset();
+  /// ==========
+  /// Initialise communication
+  /// ==========
+  initCommunication() {
+    // reset previous communication, if any
+    // reset();
 
-    ///
-    /// Open a new WebSocket communication
-    ///
-    try {
-      _channel = new IOWebSocketChannel.connect("ws://localhost:34263");
+    // Initiate communication
+    _channel = IO.io('http://127.0.0.1:3000', <String, dynamic>{
+      'transports': ['websocket'],
+        // 'extraHeaders': {'foo': 'bar'} // optional
+    });
+    _channel.connect();
+    _isOn = true;
+    _channel.on('connect', (_) {
+      print('connected');
+      _channel.emit('msg', 'test');
+    });
+  }
 
-      ///
-      /// Start listening to new notifications / messages
-      ///
-      _channel.stream.listen(_onReceptionOfMessageFromServer);
-    } catch(e){
-      ///
-      /// General error handling
-      /// TODO
-      ///
-      print(e);
+  // Resets communication
+  reset() {
+    if (_channel != null) {
+      _channel.destroy();
+      _isOn = false;
     }
   }
 
-  /// ----------------------------------------------------------
-  /// Closes the WebSocket communication
-  /// ----------------------------------------------------------
-  reset(){
-    if (_channel != null){
-      if (_channel.sink != null){
-        _channel.sink.close();
-        _isOn = false;
-      }
+  // Sends a message to the server
+  send(String message, String data) {
+    if (_isOn == true) {
+      _channel.emit(message, data);
     }
   }
 
-  /// ---------------------------------------------------------
-  /// Sends a message to the server
-  /// ---------------------------------------------------------
-  send(String message){
-    if (_channel != null){
-      if (_channel.sink != null && _isOn){
-        _channel.sink.add(message);
-      }
-    }
-  }
-
-  /// ---------------------------------------------------------
+   /// ---------------------------------------------------------
   /// Adds a callback to be invoked in case of incoming
   /// notification
   /// ---------------------------------------------------------

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -107,6 +107,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1+1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.11.4"
   matcher:
     dependency: transitive
     description:
@@ -189,6 +196,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  socket_io_client:
+    dependency: "direct main"
+    description:
+      name: socket_io_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.9"
+  socket_io_common:
+    dependency: transitive
+    description:
+      name: socket_io_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.1"
   source_span:
     dependency: transitive
     description:
@@ -252,13 +273,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
-  web_socket_channel:
-    dependency: "direct main"
-    description:
-      name: web_socket_channel
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  web_socket_channel: "^1.0.8"
+  socket_io_client: ^0.9.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Frontend changes with respect to #22 because:

- Websockets uses "ws" protocol which won't connect to the current "http" protocol used by `socket.io` implementation, hence the frontend needed to change.

@ankitjena Use these frontend changes to modify the backend. :tada: