### PR TITLE
Set socketid of a player when he/she connects

### DIFF
--- a/lib/components/appbar.dart
+++ b/lib/components/appbar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:literature/utils/audio.dart';
+import 'package:literature/utils/game_communication.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class GlobalAppBar extends StatefulWidget implements PreferredSizeWidget  {
@@ -48,6 +49,9 @@ class _GlobalAppBarState extends State<GlobalAppBar> {
       leading: IconButton(
         onPressed: () {
           Navigator.of(context).pop();
+          // Close socket connection
+          // after user presses back.
+          game.disconnect();
         },
         icon: Icon(Icons.arrow_back_ios),
         color: Color(0xFF303f9f),

--- a/lib/models/player.dart
+++ b/lib/models/player.dart
@@ -6,7 +6,7 @@ class Player {
   // Name of the player
   String name;
   // ID of a player
-  int id;
+  String id;
 
   // Constructor
   Player({

--- a/lib/screens/creategame.dart
+++ b/lib/screens/creategame.dart
@@ -16,6 +16,7 @@ class CreateGame extends StatefulWidget {
 }
 
 class _CreateGame extends State<CreateGame> {
+  String playerId;
 
   @override
   void initState() {
@@ -31,10 +32,13 @@ class _CreateGame extends State<CreateGame> {
     game.removeListener(_startConnection);
   }
 
-  // Just an empty stub here that
-  // initiates the communication.
+  // Initiates the communication.
   _startConnection(message) {
-    switch(message) {
+    switch(message["action"]) {
+      case "set_id":
+        // Set the player ID.
+        playerId = message["data"]["player_id"];
+        break;
       default:
         break;
     }
@@ -96,7 +100,10 @@ class _CreateGame extends State<CreateGame> {
                             onTap: () {
                               Navigator.push(
                                 context,
-                                MaterialPageRoute(builder: (context) => CreateRoom(audioController)),
+                                MaterialPageRoute(
+                                  builder: (context) =>
+                                  CreateRoom(audioController, playerId)
+                                ),
                               );
                             },
                             child: Container(
@@ -124,7 +131,10 @@ class _CreateGame extends State<CreateGame> {
                             onTap: () {
                               Navigator.push(
                                 context,
-                                MaterialPageRoute(builder: (context) => JoinRoom(audioController)),
+                                MaterialPageRoute(
+                                  builder: (context) =>
+                                  JoinRoom(audioController, playerId)
+                                ),
                               );
                             },
                             child: Container(
@@ -152,7 +162,10 @@ class _CreateGame extends State<CreateGame> {
                             onTap: () {
                               Navigator.push(
                                 context,
-                                MaterialPageRoute(builder: (context) => JoinRoom(audioController)),
+                                MaterialPageRoute(
+                                  builder: (context) =>
+                                  JoinRoom(audioController, playerId)
+                                ),
                               );
                             },
                             child:Container(

--- a/lib/screens/creategame.dart
+++ b/lib/screens/creategame.dart
@@ -3,7 +3,6 @@ import 'package:literature/components/appbar.dart';
 import 'package:literature/screens/joinroom.dart';
 import 'package:literature/screens/createroom.dart';
 import 'package:literature/utils/audio.dart';
-import 'package:literature/utils/game_communication.dart';
 
 
 class CreateGame extends StatefulWidget {
@@ -21,27 +20,10 @@ class _CreateGame extends State<CreateGame> {
   @override
   void initState() {
     super.initState();
-
-    // connect to the socket
-    game.addListener(_startConnection);
   }
 
   void dispose() {
     super.dispose();
-
-    game.removeListener(_startConnection);
-  }
-
-  // Initiates the communication.
-  _startConnection(message) {
-    switch(message["action"]) {
-      case "set_id":
-        // Set the player ID.
-        playerId = message["data"]["player_id"];
-        break;
-      default:
-        break;
-    }
   }
 
   @override
@@ -102,7 +84,7 @@ class _CreateGame extends State<CreateGame> {
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) =>
-                                  CreateRoom(audioController, playerId)
+                                  CreateRoom(audioController)
                                 ),
                               );
                             },
@@ -133,7 +115,7 @@ class _CreateGame extends State<CreateGame> {
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) =>
-                                  JoinRoom(audioController, playerId)
+                                  JoinRoom(audioController)
                                 ),
                               );
                             },
@@ -164,7 +146,7 @@ class _CreateGame extends State<CreateGame> {
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) =>
-                                  JoinRoom(audioController, playerId)
+                                  JoinRoom(audioController)
                                 ),
                               );
                             },

--- a/lib/screens/createroom.dart
+++ b/lib/screens/createroom.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:literature/components/appbar.dart';
 import 'package:literature/models/player.dart';
@@ -11,8 +13,13 @@ import 'package:literature/utils/loader.dart';
 class CreateRoom extends StatefulWidget {
   // Initialise AudioPlayer instance
   final AudioController audioController;
+
+  /// TODO: Remove this after player object
+  /// is in the global namespace.
+  final playerId;
+
   // Passed -> "creategame.dart"
-  CreateRoom(this.audioController);
+  CreateRoom(this.audioController, this.playerId);
 
   @override
   _CreateRoomState createState() => _CreateRoomState();
@@ -64,6 +71,7 @@ class _CreateRoomState extends State<CreateRoom> {
         // Need username matching in the db for any room.
         currPlayer = new Player(
             name: _name.text,
+            id: widget.playerId,
             lobbyLeader: (message["data"]["lobbyLeader"])["name"] == _name.text
                 ? true
                 : false);
@@ -119,9 +127,9 @@ class _CreateRoomState extends State<CreateRoom> {
   /// -----------------------------------------
   _onCreateGame() {
     // Send a message to server to create a new game
-    // and then move to join room page
-
-    game.send("create_game", _name.text);
+    // and then move to join room page.
+    Map message = { "name": _name.text, "playerId": widget.playerId };
+    game.send("create_game", json.encode(message));
     setState(() {
       isLoading = true;
     });

--- a/lib/screens/joinroom.dart
+++ b/lib/screens/joinroom.dart
@@ -14,12 +14,8 @@ class JoinRoom extends StatefulWidget {
   // Initialise AudioPlayer instance
   final AudioController audioController;
 
-  /// TODO: Remove this after player object
-  /// is in the global namespace.
-  final String playerId;
-
   // Passed -> "creategame.dart"
-  JoinRoom(this.audioController, this.playerId);
+  JoinRoom(this.audioController);
 
   @override
   _JoinRoomState createState() => _JoinRoomState();
@@ -31,6 +27,7 @@ class _JoinRoomState extends State<JoinRoom> {
   Player currPlayer;
   List<dynamic> playersList = <dynamic>[];
   bool isLoading = false;
+  String playerId;
   @override
   void initState() {
     super.initState();
@@ -57,6 +54,12 @@ class _JoinRoomState extends State<JoinRoom> {
   /// -------------------------------------------------------------------
   _joinRoomListener(Map message) {
     switch (message["action"]) {
+      case "set_id":
+        // Set the player ID.
+        playerId = message["data"]["player_id"];
+        Map joinDetails = {"roomId": _roomId.text, "name": _name.text, "playerId": playerId};
+        game.send("join_game", json.encode(joinDetails));
+        break;
 
       ///
       /// Each time a new player joins, we need to
@@ -72,7 +75,7 @@ class _JoinRoomState extends State<JoinRoom> {
           // print(playersList);
           currPlayer = new Player(name: _name.text);
           // Assign the ID of the player
-          currPlayer.id = widget.playerId;
+          currPlayer.id = playerId;
         }
         // force rebuild
         Navigator.push(
@@ -140,8 +143,9 @@ class _JoinRoomState extends State<JoinRoom> {
   /// Sends a message to server on room join request
   ///
   _onJoinGame() {
-    Map joinDetails = {"roomId": _roomId.text, "name": _name.text, "playerId": widget.playerId};
-    game.send("join_game", json.encode(joinDetails));
+    // Connect to the
+    // socket.
+    game.connect();
     setState(() {
       isLoading = true;
     });

--- a/lib/screens/joinroom.dart
+++ b/lib/screens/joinroom.dart
@@ -13,8 +13,13 @@ import 'package:literature/utils/loader.dart';
 class JoinRoom extends StatefulWidget {
   // Initialise AudioPlayer instance
   final AudioController audioController;
+
+  /// TODO: Remove this after player object
+  /// is in the global namespace.
+  final String playerId;
+
   // Passed -> "creategame.dart"
-  JoinRoom(this.audioController);
+  JoinRoom(this.audioController, this.playerId);
 
   @override
   _JoinRoomState createState() => _JoinRoomState();
@@ -67,11 +72,7 @@ class _JoinRoomState extends State<JoinRoom> {
           // print(playersList);
           currPlayer = new Player(name: _name.text);
           // Assign the ID of the player
-          playersList.forEach((player) {
-            if (player["name"] == _name.text) {
-              currPlayer.id = player["id"];
-            }
-          });
+          currPlayer.id = widget.playerId;
         }
         // force rebuild
         Navigator.push(
@@ -139,7 +140,7 @@ class _JoinRoomState extends State<JoinRoom> {
   /// Sends a message to server on room join request
   ///
   _onJoinGame() {
-    Map joinDetails = {"roomId": _roomId.text, "name": _name.text};
+    Map joinDetails = {"roomId": _roomId.text, "name": _name.text, "playerId": widget.playerId};
     game.send("join_game", json.encode(joinDetails));
     setState(() {
       isLoading = true;

--- a/lib/utils/game_communication.dart
+++ b/lib/utils/game_communication.dart
@@ -1,6 +1,3 @@
-import 'dart:convert';
-
-import 'package:flutter/foundation.dart';
 import 'package:literature/utils/websocket.dart';
 
 ///
@@ -10,44 +7,18 @@ import 'package:literature/utils/websocket.dart';
 GameCommunication game = new GameCommunication();
 
 class GameCommunication {
-  static final GameCommunication _game = new GameCommunication._internal();
-
-  ///
-  /// At first initialization, the player has not yet provided any name
-  ///
-  String _playerName = "";
-
-  ///
-  /// Before the "join" action, the player has no unique ID
-  ///
-  String _playerID = "";
-
-  /// Reuse the same instance of 
-  /// the class using "factory" identifier.
-  factory GameCommunication(){
-    return _game;
-  }
-
-  // Private Constructor for the class.
-  GameCommunication._internal(){
-    ///
-    /// Let's initialize the WebSockets communication
-    ///
+  connect() {
     socket.initCommunication();
   }
+
+  disconnect() {
+    socket.reset();
+  }  
 
   /// ----------------------------------------------------------
   /// Common method to send requests to the server
   /// ----------------------------------------------------------
   send(String action, String data){
-    ///
-    /// When a player joins, we need to record the name
-    /// he provides
-    ///
-    if (action == 'join'){
-      _playerName = data;
-    }
-
     ///
     /// Send the action to the server
     /// To send the message, we need to serialize the JSON 

--- a/lib/utils/websocket.dart
+++ b/lib/utils/websocket.dart
@@ -38,7 +38,7 @@ class WebSocket {
     // Initiate communication 
     // To Connect to the Localhost in the App, Read this following
     // https://stackoverflow.com/questions/4779963/how-can-i-access-my-localhost-from-my-android-device
-    _channel = IO.io('http://192.168.1.103:3000/', <String, dynamic>{
+    _channel = IO.io('http://localhost:3000/', <String, dynamic>{
       'transports': ['websocket'],
         // 'extraHeaders': {'foo': 'bar'} // optional
     });
@@ -146,6 +146,15 @@ class WebSocket {
         callback(message);
       });
     });
-
+    // On event set_player ID
+    socket.on("get_id", (data) {
+      Map messageRecieved = json.decode(data);
+      Map message = new Map();
+      message["data"] = messageRecieved["data"];
+      message["action"] = messageRecieved["action"];
+      _listeners.forEach((Function callback) {
+        callback(message);
+      });
+    });
   }
 }

--- a/lib/utils/websocket.dart
+++ b/lib/utils/websocket.dart
@@ -48,14 +48,17 @@ class WebSocket {
       print('connected');
       _channel.emit('msg', 'test');
     });
+    _channel.on('disconnect', (_) {
+      print('disconnected');
+    });
 
     listenForEvents(_channel);
   }
 
   // Resets communication
   reset() {
-    if (_channel != null) {
-      _channel.destroy();
+    if (_isOn == true) {
+      _channel.close();
       _isOn = false;
     }
   }

--- a/node_server/src/models/Room.ts
+++ b/node_server/src/models/Room.ts
@@ -7,7 +7,7 @@ autoIncrement.initialize(connection);
 
 type Player = {
   name: string;
-  id: number;
+  id: String;
 }
 
 export enum GameStatus {
@@ -26,12 +26,12 @@ export type RoomDocument = mongoose.Document & {
 const roomSchema = new mongoose.Schema({
   players: [{
     _id: false,
-    id: Number,
+    id: String,
     name: String
   }],
   status: String,
   lobbyLeader: {
-    id: Number,
+    id: String,
     name: String
   }
 });


### PR DESCRIPTION
The motive behind this Pull request is as follows:
- The player id currently made served no purpose yet.
- The player id now is same as the socket connection id, which would be sent along with every request (it can be used in the future if we want to).